### PR TITLE
Fix table positioning on ticker page

### DIFF
--- a/source/application/pages/ticker/ticker.less
+++ b/source/application/pages/ticker/ticker.less
@@ -108,7 +108,7 @@
     }
 
     .table-container {
-        margin: auto;
+        margin: 0 auto;
         max-width: 1200px;
         height: 100%;
         width: 100%;


### PR DESCRIPTION
Added `margin: 0 auto` to the table on the ticker page.