### PR TITLE
Add scrollbar to overflowing menu

### DIFF
--- a/source/application/components/tray/sidebar.vue
+++ b/source/application/components/tray/sidebar.vue
@@ -151,7 +151,6 @@
         }
 
         .menu-section {
-            padding-top: 30px;
             flex: 1 1 auto;
             max-height: 100%;
             background: @dark-blue;

--- a/source/application/components/tray/sidebar.vue
+++ b/source/application/components/tray/sidebar.vue
@@ -78,10 +78,11 @@
         max-width: 300px;
 
         .logo-container {
-            flex: 1 1 auto;
+            flex: 1 0 auto;
             background: transparent;
             flex-direction: column;
             max-height: 300px;
+            height: 300px;
             display: flex;
 
             &:before,
@@ -150,10 +151,12 @@
         }
 
         .menu-section {
-            padding: 30px 0;
+            padding-top: 30px;
             flex: 1 1 auto;
             max-height: 100%;
             background: @dark-blue;
+            overflow-y: auto;
+            overflow-x: hidden;
 
             .menu-header {
                 display: flex;
@@ -197,6 +200,7 @@
 
             .social-links {
                 display: flex;
+                flex: 0 0 auto;
                 background: @dark-blue;
                 height: 50px;
                 justify-content: center;


### PR DESCRIPTION
I added a height to the `logo-container` to keep it static.

I also removed bottom padding from the `menu-section` to get rid of that awkward space when the scrollbar reaches the bottom. This shouldn't affect the bottom spacing, since the social icons are occupying it.

Fixes: #24 