### PR TITLE
Use 'substr' to check for list; use 'trim' to check for whitespace

### DIFF
--- a/source/application/pages/news/index.vue
+++ b/source/application/pages/news/index.vue
@@ -138,7 +138,7 @@
                 // Filter for paragraphs
                 const strArr = str.split('\n').reduce((a, paragraph) => {
                     const isHeading = paragraph[0] === '#'
-                    const isUL = paragraph[0] === '* '
+                    const isUL = paragraph.substr(0, 2) === '* '
 
                     // Match for strings that:
                     // 1. Begins with a number
@@ -146,7 +146,7 @@
                     // 3. Followed by a whitespace
                     const isOL = paragraph.match(/^\d.\s/g)
 
-                    return !!paragraph && !isHeading && !isUL && !isOL
+                    return !!paragraph.trim() && !isHeading && !isUL && !isOL
                         ? a.concat(paragraph)
                         : a
                 }, [])


### PR DESCRIPTION
A few bugs that I didn't catch before.
Sorry!