### PR TITLE
Make breadcrumbs clickable on education section

### DIFF
--- a/source/application/pages/education/index.vue
+++ b/source/application/pages/education/index.vue
@@ -4,8 +4,13 @@
             <div class="meta-info">
                 <div class="breadcrumbs">
                     <div class="breadcrumb" v-for="(breadcrumb, index) in breadcrumbs">
-                        <div class="title">
-                            {{ breadcrumb }}
+                        <div class="title" v-if="index !== breadcrumbs.length - 1">
+                           <router-link :to="{name: breadcrumb.link}" tag="a">
+                              {{ breadcrumb.title }}
+                           </router-link>
+                        </div>
+                        <div class="title" v-else>
+                           {{ breadcrumb.title }}
                         </div>
 
                         <span class="spacer" v-if="index !== breadcrumbs.length - 1">
@@ -59,7 +64,13 @@
         computed: {
             section() { return this.$route },
             breadcrumbs() {
-                return this.$route.name.split('.')
+                return this.$route.name.split('.').reduce((result, crumb) => {
+                    result.push({
+                        title: crumb,
+                        link: result.length === 0 ? crumb : `${result[result.length - 1].link}.${crumb}`
+                    })
+                    return result
+                }, [])
             },
             readTime() {
                 return this.information


### PR DESCRIPTION
Breadcrumbs list is now a list of objects with title for the breadcrumb and link for the route name. Then it wraps the title in a router-link tag using the link. The currently viewed breadcrumb does not get wrapped in a link.